### PR TITLE
Filter .*\( and \).* in VENV if it is present

### DIFF
--- a/headline.zsh-theme
+++ b/headline.zsh-theme
@@ -128,7 +128,7 @@ declare -A HL_CONTENT_TEMPLATE=(
 declare -A HL_CONTENT_SOURCE=(
   USER   'echo $USER'
   HOST   'hostname -s'
-  VENV   'print ${VIRTUAL_ENV_PROMPT:-${CONDA_DEFAULT_ENV:-$(basename "$VIRTUAL_ENV")}}'
+  VENV   'print "${${${VIRTUAL_ENV_PROMPT:-${CONDA_DEFAULT_ENV:-$(basename "$VIRTUAL_ENV")}}#*\(}%)*}"'
   PATH   'print -rP "%~"'
   BRANCH 'headline-git-branch'
   STATUS 'headline-git-status'


### PR DESCRIPTION
When I activate a Python virtual environment created with the venv module, I expect to see:
<img width="351" height="57" alt="Снимок экрана 2025-10-22 в 20 20 02" src="https://github.com/user-attachments/assets/d42b94a1-a27e-45ca-89a9-5658b7d97b6e" />
but instead I get:
<img width="373" height="57" alt="Снимок экрана 2025-10-22 в 20 19 01" src="https://github.com/user-attachments/assets/16073d85-daed-495a-9df0-f2fd4441a6d1" />
This change removes any characters and brackets (if present) that should appear in the prompt